### PR TITLE
🔧 Add Python 3.13 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,10 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version:
+          - "3.11"
+          - "3.12"
+          - "3.13.0-beta - 3.13"
 
     steps:
       - name: Checkout the code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,14 @@ readme = "README.md"
 dependencies = []
 license = { file = "LICENSE" }
 classifiers = [
-    "Programming Language :: Python :: 3",
+    "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3",
+    "Topic :: System :: Logging",
 ]
 
 [project.urls]


### PR DESCRIPTION
- Test with Python 3.13 beta (or release)
- Update PyPi classifiers