### PR TITLE
✨ Add audit log validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: release
+    timeout-minutes: 60
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,11 +18,11 @@ repos:
         files: ^requirements-dev.txt$
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.3
+    rev: v0.6.1
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black

--- a/audit_log/exceptions.py
+++ b/audit_log/exceptions.py
@@ -2,5 +2,9 @@ class AuditError(Exception):
     """General error in audit library"""
 
 
+class AuditValidationError(Exception):
+    """Audit logging called without proper data"""
+
+
 class AuditPrincipalError(AuditError):
     """Error with the principal"""

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,8 +1,16 @@
+from uuid import UUID
+
 import pytest
 from freezegun import freeze_time
 
+from audit_log.exceptions import AuditValidationError
 from audit_log.log import log, to_serializable
 from audit_log.schema import ActionType, OutcomeResult, Principal, PrincipalType
+
+
+@pytest.fixture
+def sample_principal() -> Principal:
+    return Principal(PrincipalType.USER, authority="test", id="pytester")
 
 
 @pytest.mark.parametrize(
@@ -34,7 +42,8 @@ def test_to_serializable_exception():
         "result",
         "request_id",
         "outcome_reason",
-        "principal",
+        "before",
+        "after",
         "expected_log",
     ),
     [
@@ -45,29 +54,73 @@ def test_to_serializable_exception():
             OutcomeResult.SUCCEEDED,
             "123e4567-e89b-12d3-a456-426614174000",
             "Some reason",
-            Principal(
-                type=PrincipalType.USER,
-                authority="respect_mine",
-                id="test.user@test.com",
-            ),
+            None,
+            {"test": "yes"},
             '{"type": "audit-log", "timestamp": "2022-04-20T12:00:00+00:00", "level": "INFO", "version": 1, '
             '"resource": {"type": "test", "id": "123e4567-e89b-12d3-a456-426614174000"}, "action": {"type": '
             '"CREATE"}, "outcome": {"result": "SUCCEEDED", "reason": "Some reason", "before": null, '
+            '"after": {"test": "yes"}}, "context": {"request": {"id": "123e4567-e89b-12d3-a456-426614174000"}}, '
+            '"principal": {"type": "USER", "authority": "test", "id": "pytester"}}',
+        ),
+        (
+            ActionType.CREATE,
+            "test",
+            None,
+            OutcomeResult.DENIED,
+            "123e4567-e89b-12d3-a456-426614174000",
+            "Some reason",
+            None,
+            None,
+            '{"type": "audit-log", "timestamp": "2022-04-20T12:00:00+00:00", "level": "INFO", "version": 1, '
+            '"resource": {"type": "test", "id": null}, "action": {"type": '
+            '"CREATE"}, "outcome": {"result": "DENIED", "reason": "Some reason", "before": null, '
             '"after": null}, "context": {"request": {"id": "123e4567-e89b-12d3-a456-426614174000"}}, '
-            '"principal": {"type": "USER", "authority": "respect_mine", "id": "test.user@test.com"}}',
+            '"principal": {"type": "USER", "authority": "test", "id": "pytester"}}',
+        ),
+        (
+            ActionType.UPDATE,
+            "test",
+            "123e4567-e89b-12d3-a456-426614174000",
+            OutcomeResult.SUCCEEDED,
+            "123e4567-e89b-12d3-a456-426614174000",
+            "Some reason",
+            {"test": "maybe"},
+            {"test": "yes"},
+            '{"type": "audit-log", "timestamp": "2022-04-20T12:00:00+00:00", "level": "INFO", "version": 1, '
+            '"resource": {"type": "test", "id": "123e4567-e89b-12d3-a456-426614174000"}, "action": {"type": '
+            '"UPDATE"}, "outcome": {"result": "SUCCEEDED", "reason": "Some reason", "before": {"test": "maybe"}, '
+            '"after": {"test": "yes"}}, "context": {"request": {"id": "123e4567-e89b-12d3-a456-426614174000"}}, '
+            '"principal": {"type": "USER", "authority": "test", "id": "pytester"}}',
+        ),
+        (
+            ActionType.DELETE,
+            "test",
+            "123e4567-e89b-12d3-a456-426614174000",
+            OutcomeResult.SUCCEEDED,
+            "123e4567-e89b-12d3-a456-426614174000",
+            "Some reason",
+            {"test": "yes"},
+            None,
+            '{"type": "audit-log", "timestamp": "2022-04-20T12:00:00+00:00", "level": "INFO", "version": 1, '
+            '"resource": {"type": "test", "id": "123e4567-e89b-12d3-a456-426614174000"}, "action": {"type": '
+            '"DELETE"}, "outcome": {"result": "SUCCEEDED", "reason": "Some reason", "before": {"test": "yes"}, '
+            '"after": null}, "context": {"request": {"id": "123e4567-e89b-12d3-a456-426614174000"}}, '
+            '"principal": {"type": "USER", "authority": "test", "id": "pytester"}}',
         ),
     ],
 )
 def test_log(
-    action_type,
-    resource_type,
-    resource_id,
-    result,
-    request_id,
-    outcome_reason,
-    principal,
-    expected_log,
-    capsys,
+    action_type: ActionType,
+    resource_type: str,
+    resource_id: str | None,
+    result: OutcomeResult,
+    request_id: str | UUID | None,
+    outcome_reason: str | None,
+    before: dict | None,
+    after: dict | None,
+    expected_log: str,
+    capsys: pytest.CaptureFixture,
+    sample_principal: Principal,
 ):
     with freeze_time("2022-04-20T12:00:00+00:00"):
         log(
@@ -77,7 +130,59 @@ def test_log(
             result=result,
             request_id=request_id,
             outcome_reason=outcome_reason,
-            principal=principal,
+            principal=sample_principal,
+            before=before,
+            after=after,
         )
         printed_message = capsys.readouterr().out.strip()
         assert printed_message == expected_log
+
+
+@pytest.mark.parametrize(
+    ("action_type", "resource_id", "before", "after", "expected_error"),
+    [
+        (ActionType.CREATE, None, None, {"t": 1}, "Missing resource ID"),
+        (ActionType.CREATE, 1, None, None, "Missing 'after' with CREATE action"),
+        (
+            ActionType.UPDATE,
+            1,
+            None,
+            None,
+            "Missing 'before' and 'after' with UPDATE action",
+        ),
+        (
+            ActionType.UPDATE,
+            1,
+            None,
+            {"t": 1},
+            "Missing 'before' and 'after' with UPDATE action",
+        ),
+        (
+            ActionType.UPDATE,
+            1,
+            {"t": 1},
+            None,
+            "Missing 'before' and 'after' with UPDATE action",
+        ),
+        (ActionType.DELETE, 1, None, None, "Missing 'before' with DELETE action"),
+    ],
+)
+def test_log_validation(
+    action_type: ActionType,
+    resource_id: int | None,
+    before: dict | None,
+    after: dict | None,
+    expected_error: str,
+    sample_principal: Principal,
+):
+    with pytest.raises(AuditValidationError, match=expected_error):
+        log(
+            action_type=action_type,
+            resource_type="test/test",
+            resource_id=resource_id,
+            result=OutcomeResult.SUCCEEDED,
+            request_id="123e4567-e89b-12d3-a456-426614174000",
+            principal=sample_principal,
+            before=before,
+            after=after,
+        )


### PR DESCRIPTION
Enforces the following concepts if the outcome result is SUCCEEDED:
1. The resource_id cannot be null
2. CREATE actions need `after` to be not null
3. UPDATE actions need `before` and `after` to be not null
4. DELETE actions need `before` to be not null

Bonus changes:
- Upgrade pre-commit hooks
- Ensure there's a timeout set for the release workflow