### PR TITLE
🔧 Update Python 3.13 version in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14.0-beta - 3.14"
 
     steps:
       - name: Checkout the code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         python-version:
           - "3.11"
           - "3.12"
-          - "3.13.0-beta - 3.13"
+          - "3.13"
 
     steps:
       - name: Checkout the code


### PR DESCRIPTION
Python 3.13 was released in Oct 2024 so we can drop the beta versions and treat it as any other Python version.

Edit: Since this has been open a while we now have Python 3.14 available for beta testing