### PR TITLE
🔧 Fix typo in workflow permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permmissions:
+    permissions:
       contents: read
     strategy:
       matrix:


### PR DESCRIPTION
Permissions had a typo, wasn't caught in review